### PR TITLE
feat: add Customer.io CDP reverse-proxy route (/cio)

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const TARGETS = {
         api: 'https://api2.amplitude.com',
         cdn: 'https://cdn.amplitude.com',
         config: 'https://sr-client-cfg.amplitude.com'
-    }
+    },
+    customerio: 'https://cdp.customer.io' // US region CDP intake/assets
 };
 
 const app = express();
@@ -83,6 +84,37 @@ const amplitudeConfigProxy = createProxyMiddleware({
     },
 });
 
+// Customer.io CDP Proxy Middleware
+// Strips the leading "/cio" and forwards the remaining path + query verbatim
+// to cdp.customer.io (US region). Method, headers, and raw body are preserved.
+const customerioProxy = createProxyMiddleware({
+    target: TARGETS.customerio,
+    changeOrigin: true,
+    logLevel: 'debug',
+    pathRewrite: {
+        '^/cio/': '/', // Remove /cio/ prefix when forwarding to Customer.io
+        '^/cio$': '/', // Handle bare /cio with no trailing slash
+    },
+    // http-proxy-middleware v3 expects lifecycle hooks under `on`.
+    on: {
+        proxyReq: (proxyReq, req, res) => {
+            proxyReq.setHeader('Host', new URL(TARGETS.customerio).hostname);
+            proxyReq.setHeader('X-Forwarded-For', req.ip);
+        },
+        proxyRes: (proxyRes, req, res) => {
+            // Never cache event intake (POST /cio/v1/*). Allow a short cache
+            // only for idempotent GET asset/settings responses.
+            const reqPath = req.originalUrl || req.url;
+            const isEventIntake = req.method === 'POST' && /^\/cio\/v1\//.test(reqPath);
+            if (isEventIntake) {
+                proxyRes.headers['cache-control'] = 'no-store';
+            } else if (req.method === 'GET' && !proxyRes.headers['cache-control']) {
+                proxyRes.headers['cache-control'] = 'public, max-age=60';
+            }
+        },
+    },
+});
+
 // Route Datadog requests
 app.use('/dd', datadogProxy);
 
@@ -91,10 +123,14 @@ app.use('/ampli/api', amplitudeApiProxy);
 app.use('/ampli/cdn', amplitudeCdnProxy);
 app.use('/ampli/config', amplitudeConfigProxy);
 
+// Route Customer.io requests
+app.use('/cio', customerioProxy);
+
 app.listen(PORT, () => {
     console.log(`Analytics proxy listening on port ${PORT}`);
     console.log(`Datadog requests forwarded to ${TARGETS.datadog}`);
     console.log(`Amplitude API requests forwarded to ${TARGETS.amplitude.api}`);
     console.log(`Amplitude CDN requests forwarded to ${TARGETS.amplitude.cdn}`);
     console.log(`Amplitude Config requests forwarded to ${TARGETS.amplitude.config}`);
+    console.log(`Customer.io requests forwarded to ${TARGETS.customerio}`);
 }); 


### PR DESCRIPTION
## Summary
- Adds a `/cio` reverse-proxy route on the same first-party origin (port `8080`) that already serves `/dd`.
- Strips the leading `/cio` and forwards the remaining path + query verbatim to `https://cdp.customer.io` (US region only), preserving HTTP method, request headers (incl. `Content-Type`), and the raw request body.
- Returns the upstream response (status, headers, body) verbatim. Allows `GET`/`POST`/`OPTIONS` with CORS pass-through.
- Caching: `POST /cio/v1/*` (event intake) -> `Cache-Control: no-store`; `GET` asset/settings responses get a short `public, max-age=60`.

Note: uses `http-proxy-middleware` v3's `on: { proxyReq, proxyRes }` hook syntax so the cache logic actually runs (the existing Datadog/Amplitude blocks use the v3-ignored top-level `onProxyReq`, left unchanged as out of scope).

## Test plan
- [x] `GET /cio/v1/projects/<key>/settings` -> reaches upstream, `Cache-Control: public, max-age=60`
- [x] `GET /cio/next-integrations/...` -> reaches upstream, short cache
- [x] `POST /cio/v1/t` -> 200, `Cache-Control: no-store`
- [x] `POST /cio/v1/batch` -> 200, `Cache-Control: no-store`
- [x] `OPTIONS /cio/v1/t` -> 204 (CORS preflight)

Made with [Cursor](https://cursor.com)